### PR TITLE
enhance AMS prodcut lock (#8)

### DIFF
--- a/ibroker/ams-api-gateway/src/main/java/com/intel/iot/ams/api/ClientMgrAPIs.java
+++ b/ibroker/ams-api-gateway/src/main/java/com/intel/iot/ams/api/ClientMgrAPIs.java
@@ -7,6 +7,7 @@ package com.intel.iot.ams.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.intel.iot.ams.task.AmsTaskType;
 import com.intel.iot.ams.api.requestbody.UpdateAmsClientInfo;
 import com.intel.iot.ams.entity.AmsClient;
 import com.intel.iot.ams.entity.ClientDeviceMapping;
@@ -408,6 +409,19 @@ public class ClientMgrAPIs {
 
     if (info.getProductLock() != null) {
       client.setProductLock(info.getProductLock());
+      /** if the product lock switch: on (true) --> off (false)
+       *  should create ams task to calculate product change
+       */
+      if (!info.getProductLock()){
+        /** Create a AmsTask to calculate product changes of this client */
+        AmsTask task = new AmsTask();
+        task.setTaskType(AmsTaskType.CALCULATE_PRODUCT_CHANGES);
+        task.setTaskCreateTime(new Date());
+        JsonObject jTaskProperty = new JsonObject();
+        jTaskProperty.addProperty("client_uuid", client.getClientUuid());
+        task.setTaskProperties(jTaskProperty.toString());
+        taskSrv.save(task);
+      }
     }
 
     clientSrv.update(client);

--- a/ibroker/ams-device-service/src/main/java/com/intel/iot/ams/api/ClientAllCfgResource.java
+++ b/ibroker/ams-device-service/src/main/java/com/intel/iot/ams/api/ClientAllCfgResource.java
@@ -78,6 +78,15 @@ public class ClientAllCfgResource extends CoapResource {
       return;
     }
 
+    if (client.getProductLock()){
+      logger.info("Client:"+client.getClientUuid()+" has been locked, can not update config");
+      resp = new Response(ResponseCode.BAD_REQUEST);
+      resp.setPayload("client:" + shortId + " has been locked, can not update config");
+      exchange.respond(resp);
+      return;
+    }
+
+
     //get template_item template list in customized template content
     AmsTemplate template =
         ServiceBundle.getInstance().getTemplateSrv().findByName(client.getTemplateName());

--- a/ibroker/ams-device-service/src/main/java/com/intel/iot/ams/task/AmsTaskHandler.java
+++ b/ibroker/ams-device-service/src/main/java/com/intel/iot/ams/task/AmsTaskHandler.java
@@ -131,6 +131,18 @@ public class AmsTaskHandler implements Runnable {
     if (client == null) {
       return false;
     }
+    /**
+      if client's prodcut lock is true, should not calculate product change
+      and old product changes items should be deleted
+     */
+
+    if (client.getProductLock()){
+      logger.info("Client:"+client.getClientUuid()+" has been locked, can not calculate prodcut changes");
+      // delete old product changes
+      changeSrv.removeByClientUuid(client.getClientUuid());
+      // delete the task item
+      return ture;
+    }
 
     /** Calculate product changes of this client */
 


### PR DESCRIPTION
* enhance AMS prodcut lock
 - when product lock is on:
    - ams device server will not calculate product change and delete old product changes items
    - ams device server will not update client's configuration
    - create task when product lock is off